### PR TITLE
Integrate Maven to remove transivitive dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ void junit_extension_can_be_loaded() throws ClassNotFoundException {
 }
 
 @Test
-@ModifiedClasspath(excludeJars = "junit-jupiter-api")
+@ModifiedClasspath(excludeGavs = "junit-jupiter-api")
 void junit_extension_cannot_be_loaded() {
     assertThatExceptionOfType(ClassNotFoundException.class)
         .isThrownBy(() -> Class.forName("org.junit.jupiter.api.extension.Extension"));

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
+        <maven-core.version>3.6.3</maven-core.version>
+
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
         <assertj.version>3.13.2</assertj.version>
 
@@ -52,6 +54,12 @@
     </developers>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven-core.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/ClasspathContext.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/ClasspathContext.java
@@ -1,0 +1,23 @@
+package com.github.fridujo.junit.extension.classpath;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import com.github.fridujo.junit.extension.classpath.maven.Maven;
+
+class ClasspathContext {
+
+    private Maven maven;
+
+    Optional<Maven> getMaven(PathElement path) {
+        if (maven == null) {
+            maven = Maven.from(path).orElse(null);
+        }
+        return Optional.ofNullable(maven);
+    }
+
+    Set<Gav> listDependencies(PathElement path) {
+        return getMaven(path).map(m -> m.listDependencies(path)).orElse(Collections.emptySet());
+    }
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/Gav.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/Gav.java
@@ -10,16 +10,16 @@ public class Gav {
     public final String artifactId;
     public final String groupId;
     public final String version;
-    private final Pattern pathPattern;
+    private final Pattern jarPattern;
 
-    private Gav(String artifactId, String groupId, String version) {
+    public Gav(String artifactId, String groupId, String version) {
         this.artifactId = artifactId;
         this.groupId = groupId;
         this.version = version;
-        this.pathPattern = buildPathPattern(artifactId, groupId, version);
+        this.jarPattern = buildJarPattern(artifactId, groupId, version);
     }
 
-    private static Pattern buildPathPattern(String artifactId, String groupId, String version) {
+    private static Pattern buildJarPattern(String artifactId, String groupId, String version) {
         if (groupId == null) {
             return Pattern.compile("(.*)" + Pattern.quote(artifactId) + "([^\\" + File.separatorChar + "]*)" + Pattern.quote(".jar"));
         }
@@ -35,15 +35,28 @@ public class Gav {
     }
 
     public static Gav parse(String gav) {
-        final Matcher matcher = GAV_PATTERN.matcher(gav);
+        final Matcher matcher = GAV_PATTERN.matcher(gav.trim());
         if (!matcher.matches()) {
             throw new IllegalArgumentException("Not a GAV expression");
         }
         return new Gav(matcher.group("artifactId"), matcher.group("groupId"), matcher.group("version"));
     }
 
-    public boolean matchesPath(String rawPath) {
-        return pathPattern.matcher(rawPath).matches();
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (groupId != null) {
+            sb.append(groupId).append(':');
+        }
+        sb.append(artifactId);
+        if (version != null) {
+            sb.append(':').append(version);
+        }
+        return sb.toString();
+    }
+
+    public boolean matchesJar(String rawJarPath) {
+        return jarPattern.matcher(rawJarPath).matches();
     }
 
     @Override

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/ModifiedClasspath.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/ModifiedClasspath.java
@@ -16,8 +16,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(ModifiedClasspathExtension.class)
 public @interface ModifiedClasspath {
+
     /**
-     * Will remove jars matching the given GAV (groupId:artifactId:version).<br>
+     * Will remove Jars matching the given GAV (groupId:artifactId:version).<br>
      * <p>
      * Gav can have the following structures:
      * <ul>
@@ -25,6 +26,24 @@ public @interface ModifiedClasspath {
      * <li>groupId:artifactId</li>
      * <li>groupId:artifactId:version</li>
      * </ul>
+     * <p>
+     * If the matching Jars are in a <b>Maven</b> repository, their dependencies (transitive or not) will also be excluded.
+     */
+    String[] excludeGavs() default {};
+
+    /**
+     * Will remove Jars matching the given GAV (groupId:artifactId:version).<br>
+     * <p>
+     * Gav can have the following structures:
+     * <ul>
+     * <li><b>artifactId</b>: aka JAR name</li>
+     * <li><b>groupId:artifactId</b></li>
+     * <li><b>groupId:artifactId:version</b></li>
+     * </ul>
+     * <p>
+     * <p>
+     * In opposition to {@link #excludeGavs()}, their will be no attempt to list and exclude dependencies.
      */
     String[] excludeJars() default {};
+
 }

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/NoMatchingClasspathElementFoundException.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/NoMatchingClasspathElementFoundException.java
@@ -1,0 +1,8 @@
+package com.github.fridujo.junit.extension.classpath;
+
+public class NoMatchingClasspathElementFoundException extends RuntimeException {
+
+    public NoMatchingClasspathElementFoundException(Gav gav) {
+        super(gav.toString() + " found no match in classpath");
+    }
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/Streams.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/Streams.java
@@ -1,0 +1,17 @@
+package com.github.fridujo.junit.extension.classpath;
+
+import java.util.Iterator;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+public class Streams {
+
+    public static <T, U> U reduce(Stream<T> stream, U initialValue, BiFunction<U, T, U> accumulator) {
+        U value = initialValue;
+        Iterator<T> iterator = stream.iterator();
+        while (iterator.hasNext()) {
+            value = accumulator.apply(value, iterator.next());
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/maven/Maven.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/maven/Maven.java
@@ -1,0 +1,54 @@
+package com.github.fridujo.junit.extension.classpath.maven;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.model.Model;
+
+import com.github.fridujo.junit.extension.classpath.Gav;
+import com.github.fridujo.junit.extension.classpath.PathElement;
+
+public class Maven extends MavenOperations {
+
+    private final Map<PathElement, Set<Gav>> dependenciesCache = new LinkedHashMap<PathElement, Set<Gav>>() {
+        public boolean removeEldestEntry(Map.Entry eldest) {
+            return size() > 1000;
+        }
+    };
+
+    public Maven(String localRepo) {
+        super(localRepo);
+    }
+
+    public static Optional<Maven> from(PathElement jarPath) {
+        return getNonEffectiveModel(jarPath)
+            .map(nonEffectiveModel -> new Maven(deduceLocalRepo(jarPath, nonEffectiveModel)));
+    }
+
+    private static String deduceLocalRepo(PathElement jarPath, Model nonEffectiveModel) {
+        String rawPath = jarPath.toPath().toString();
+        String groupId = getGroupId(nonEffectiveModel);
+        String version = getVersion(nonEffectiveModel);
+        String mavenInternalStructure = groupId.replace('.', File.separatorChar) + File.separatorChar + nonEffectiveModel.getArtifactId() + File.separatorChar + version + File.separatorChar;
+
+        int i = rawPath.indexOf(mavenInternalStructure);
+        if (i < 0) {
+            throw new IllegalStateException("Loaded a Maven dependency outside a repository");
+        }
+
+        return rawPath.substring(0, i);
+    }
+
+    public Set<Gav> listDependencies(PathElement jarPath) {
+        return dependenciesCache.computeIfAbsent(jarPath, p -> loadMavenProject(p)
+            .map(mp -> mp.getDependencies().stream()
+                .filter(d -> !"test".equals(d.getScope()) && !d.isOptional())
+                .map(d -> new Gav(d.getArtifactId(), d.getGroupId(), d.getVersion()))
+                .collect(Collectors.toSet())).orElseGet(Collections::emptySet));
+    }
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/maven/MavenOperations.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/maven/MavenOperations.java
@@ -1,0 +1,147 @@
+package com.github.fridujo.junit.extension.classpath.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.DefaultModelBuilder;
+import org.apache.maven.model.building.DefaultModelBuilderFactory;
+import org.apache.maven.model.building.DefaultModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingException;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingResult;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectModelResolver;
+import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
+import org.apache.maven.repository.internal.DefaultVersionResolver;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.DefaultArtifactResolver;
+import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
+import org.eclipse.aether.internal.impl.DefaultRepositoryConnectorProvider;
+import org.eclipse.aether.internal.impl.DefaultRepositoryEventDispatcher;
+import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
+import org.eclipse.aether.internal.impl.DefaultSyncContextFactory;
+import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+
+import com.github.fridujo.junit.extension.classpath.PathElement;
+
+abstract class MavenOperations {
+
+    private static final String ESC_SEP = Pattern.quote(File.separator);
+
+    private static final Pattern MAVEN_ARTIFACT_PATH_PATTERN = Pattern.compile("(?:.*)" + ESC_SEP
+        + "(?<artifactId>.*)" + ESC_SEP + "(?<version>.*)" + ESC_SEP
+        + "\\k<artifactId>-\\k<version>" + Pattern.quote(".jar"));
+
+    private final DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+    private final ProjectModelResolver modelResolver = new ProjectModelResolver(
+        session,
+        null,
+        new DefaultRepositorySystem()
+            .setVersionRangeResolver(new DefaultVersionRangeResolver())
+            .setArtifactResolver(new DefaultArtifactResolver()
+                .setSyncContextFactory(new DefaultSyncContextFactory())
+                .setRepositoryEventDispatcher(new DefaultRepositoryEventDispatcher())
+                .setVersionResolver(new DefaultVersionResolver())
+                .setRemoteRepositoryManager(new DefaultRemoteRepositoryManager())
+                .setRepositoryConnectorProvider(new DefaultRepositoryConnectorProvider())),
+        new DefaultRemoteRepositoryManager(),
+        Collections.emptyList(),
+        ProjectBuildingRequest.RepositoryMerging.POM_DOMINANT,
+        null
+    );
+
+    protected MavenOperations(String localRepo) {
+        try {
+            this.session.setLocalRepositoryManager(new EnhancedLocalRepositoryManagerFactory().newInstance(session, new LocalRepository(localRepo)));
+        } catch (NoLocalRepositoryManagerException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    protected static String getVersion(Model model) {
+        String version = model.getVersion();
+        if (version != null) {
+            return version;
+        }
+        if (model.getParent() == null) {
+            throw new IllegalStateException("[" + model.getArtifactId() + "] No parent POM -> undefined version");
+        }
+        return model.getParent().getVersion();
+    }
+
+    protected static String getGroupId(Model model) {
+        String groupId = model.getGroupId();
+        if (groupId != null) {
+            return groupId;
+        }
+        if (model.getParent() == null) {
+            throw new IllegalStateException("[" + model.getArtifactId() + "] No parent POM -> undefined groupId");
+        }
+        return model.getParent().getGroupId();
+    }
+
+    protected static Optional<Model> getNonEffectiveModel(PathElement jarPath) {
+        Optional<Path> pomPath = getPomPath(jarPath);
+
+        return pomPath.map(pp -> {
+            MavenXpp3Reader reader = new MavenXpp3Reader();
+            try (InputStream is = Files.newInputStream(pp)) {
+                return reader.read(is);
+            } catch (IOException | XmlPullParserException e) {
+                return null;
+            }
+        });
+    }
+
+    private static Optional<Path> getPomPath(PathElement jarPath) {
+        String rawPath = jarPath.toPath().toString();
+        if (!rawPath.endsWith(".jar")) {
+            return Optional.empty();
+        }
+        Path pomPath = Paths.get(rawPath.substring(0, rawPath.length() - 4) + ".pom");
+        if (!Files.exists(pomPath)) {
+            return Optional.empty();
+        }
+        return Optional.of(pomPath);
+    }
+
+    /**
+     * This method is relatively slow.<br>
+     * Considering that it will be called hundreds of times, even if it take only 10ms (90th),
+     * the overall time will be above seconds.
+     * <p>
+     * This is why most of the results of this methods must be cached, to avoid degrading performances proportionally to the number of uses.
+     */
+    protected Optional<Model> loadMavenProject(PathElement jarPath) {
+        Matcher matcher = MAVEN_ARTIFACT_PATH_PATTERN.matcher(jarPath.toPath().toString());
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+        Optional<Path> pomPath = getPomPath(jarPath);
+        if (!pomPath.isPresent()) return Optional.empty();
+        try {
+            ModelBuildingRequest request = new DefaultModelBuildingRequest()
+                .setPomFile(pomPath.get().toFile())
+                .setModelResolver(modelResolver);
+            DefaultModelBuilder defaultModelBuilder = new DefaultModelBuilderFactory().newInstance();
+            ModelBuildingResult result = defaultModelBuilder.build(request);
+
+            return Optional.of(result.getEffectiveModel());
+        } catch (ModelBuildingException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/GavTest.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/GavTest.java
@@ -1,6 +1,7 @@
 package com.github.fridujo.junit.extension.classpath;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.File;
 
@@ -23,6 +24,7 @@ class GavTest {
         softly.assertThat(gav.artifactId).isEqualTo(artifactId);
         softly.assertThat(gav.groupId).isEqualTo(groupId);
         softly.assertThat(gav.version).isEqualTo(version);
+        softly.assertThat(gav).hasToString(gavExpression);
         softly.assertAll();
     }
 
@@ -48,6 +50,17 @@ class GavTest {
     void gav_matches_against_raw_path(String gavExpression, String path, boolean expectedMatch) {
         final Gav gav = Gav.parse(gavExpression);
 
-        assertThat(gav.matchesPath(path.replace('/', File.separatorChar))).isEqualTo(expectedMatch);
+        assertThat(gav.matchesJar(path.replace('/', File.separatorChar))).isEqualTo(expectedMatch);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "''",
+        "'  '"
+    })
+    void gav_cannot_be_blank(String gavExpression) {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> Gav.parse(gavExpression))
+            .withMessage("Not a GAV expression");
     }
 }

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/PathElementTest.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/PathElementTest.java
@@ -1,0 +1,15 @@
+package com.github.fridujo.junit.extension.classpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PathElementTest {
+
+    @Test
+    void toString_displays_the_path_for_debug_purposes() {
+        assertThat(PathElement.create("/var/log/messages")).hasToString("/var/log/messages");
+    }
+    
+
+}

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/maven/MavenTest.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/maven/MavenTest.java
@@ -1,0 +1,28 @@
+package com.github.fridujo.junit.extension.classpath.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.fridujo.junit.extension.classpath.Classpath;
+import com.github.fridujo.junit.extension.classpath.Gav;
+import com.github.fridujo.junit.extension.classpath.PathElement;
+
+class MavenTest {
+
+    @Test
+    void listDependencies_resolves() {
+        Gav gav = Gav.parse("junit-jupiter-api");
+        PathElement pathElement = Classpath.current().pathElements.stream().filter(pe -> pe.matches(gav)).findFirst().get();
+
+        Set<Gav> deps = Maven.from(pathElement).get().listDependencies(pathElement);
+
+        assertThat(deps).containsOnly(
+            Gav.parse("org.junit.platform:junit-platform-commons:1.5.2"),
+            Gav.parse("org.opentest4j:opentest4j:1.2.0"),
+            Gav.parse("org.apiguardian:apiguardian-api:1.1.0")
+        );
+    }
+}


### PR DESCRIPTION
`@ModifiedClasspath(excludeGavs = "...")` now also excludes transitive dependencies (except those shared with other JARs in the classpath).

The behavior is supposed to behave as if the dependencies where removed from the build tool dependency management (Maven / Gradle).

First behavior (without excluding transitive dependencies) is still possible using `@ModifiedClasspath(excludeJars = "...")`.