### PR TITLE
Swap Context ClassLoader with modified one around test invocation

### DIFF
--- a/src/main/java/com/github/fridujo/junit/extension/classpath/ModifiedClasspathExtension.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/ModifiedClasspathExtension.java
@@ -26,10 +26,22 @@ public class ModifiedClasspathExtension implements InvocationInterceptor {
             .removeGavs(annotation.excludeGavs())
             .newClassLoader();
 
-        invokeMethodWithModifiedClasspath(
-            invocationContext.getExecutable().getDeclaringClass().getName(),
-            invocationContext.getExecutable().getName(),
-            modifiedClassLoader);
+        ClassLoader currentThreadPreviousClassLoader = replaceCurrentThreadClassLoader(modifiedClassLoader);
+
+        try {
+            invokeMethodWithModifiedClasspath(
+                invocationContext.getExecutable().getDeclaringClass().getName(),
+                invocationContext.getExecutable().getName(),
+                modifiedClassLoader);
+        } finally {
+            Thread.currentThread().setContextClassLoader(currentThreadPreviousClassLoader);
+        }
+    }
+
+    private ClassLoader replaceCurrentThreadClassLoader(ClassLoader modifiedClassLoader) {
+        ClassLoader currentThreadPreviousClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(modifiedClassLoader);
+        return currentThreadPreviousClassLoader;
     }
 
     private void invokeMethodWithModifiedClasspath(String className, String methodName, ClassLoader classLoader) {

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/ClasspathExclusionTests.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/ClasspathExclusionTests.java
@@ -42,6 +42,13 @@ class ClasspathExclusionTests {
     }
 
     @Test
+    @ModifiedClasspath(excludeJars = "guava:guava")
+    void current_thread_classLoader_is_also_replaced() {
+        assertThatExceptionOfType(ClassNotFoundException.class)
+            .isThrownBy(() -> Thread.currentThread().getContextClassLoader().loadClass("com.google.common.collect.Maps"));
+    }
+
+    @Test
     void excluding_non_matching_gav_throws() {
         assertThatExceptionOfType(NoMatchingClasspathElementFoundException.class)
             .isThrownBy(() -> Classpath.current().removeGav("grId:not_existing:1.2-RC3"))

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/PathElementTest.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/PathElementTest.java
@@ -10,6 +10,4 @@ class PathElementTest {
     void toString_displays_the_path_for_debug_purposes() {
         assertThat(PathElement.create("/var/log/messages")).hasToString("/var/log/messages");
     }
-    
-
 }


### PR DESCRIPTION
As a common pattern is to look for `Thread.currentThread().getContextClassLoader().loadClass(...)` instead of `Class.forName(...)`.