### PR TITLE
Build tool abstraction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ cache:
     directories:
         - "$HOME/.m2"
 
+before_install:
+    - "export M2_HOME=/usr/local/maven"
+
 script: "mvn verify"
 
 after_success:

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
         <assertj.version>3.14.0</assertj.version>
+        <mockito-core.version>3.2.4</mockito-core.version>
 
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.0</maven-source-plugin.version>
@@ -81,6 +82,11 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-core.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/Classpath.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/Classpath.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import com.github.fridujo.junit.extension.classpath.utils.Streams;
+
 public class Classpath {
 
     public final Set<PathElement> pathElements;
@@ -27,7 +29,7 @@ public class Classpath {
         return current(new ClasspathContext());
     }
 
-    static Classpath current(ClasspathContext context) {
+    public static Classpath current(ClasspathContext context) {
         String rawClasspath = System.getProperty("java.class.path");
         Set<PathElement> pathElements = stream(rawClasspath.split(File.pathSeparator))
             .map(PathElement::create)

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/ClasspathContext.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/ClasspathContext.java
@@ -1,23 +1,28 @@
 package com.github.fridujo.junit.extension.classpath;
 
-import java.util.Collections;
+import static java.util.Optional.empty;
+
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.Set;
 
-import com.github.fridujo.junit.extension.classpath.buildtool.maven.Maven;
+import com.github.fridujo.junit.extension.classpath.buildtool.Artifact;
+import com.github.fridujo.junit.extension.classpath.buildtool.BuildTool;
+import com.github.fridujo.junit.extension.classpath.buildtool.BuildToolResolver;
+import com.github.fridujo.junit.extension.classpath.buildtool.NoBuildToolFoundException;
+import com.github.fridujo.junit.extension.classpath.utils.Streams;
 
 public class ClasspathContext {
 
-    private Maven maven;
+    private final BuildTool buildTool;
 
-    private Optional<Maven> getMaven(PathElement path) {
-        if (maven == null) {
-            maven = Maven.from(path).orElse(null);
-        }
-        return Optional.ofNullable(maven);
+    public ClasspathContext(Set<PathElement> paths) {
+        ServiceLoader<BuildToolResolver> serviceLoader = ServiceLoader.load(BuildToolResolver.class);
+        Optional<BuildTool> buildTool = Streams.reduce(serviceLoader.iterator(), empty(), (obt1, obt2) -> obt1.isPresent() ? obt1 : obt2.resolve(paths));
+        this.buildTool = buildTool.orElseThrow(NoBuildToolFoundException::new);
     }
 
-    Set<Gav> listDependencies(PathElement path) {
-        return getMaven(path).map(m -> m.listDependencies(path)).orElse(Collections.emptySet());
+    Set<Artifact> listDependencies(PathElement path) {
+        return buildTool.listDependencies(path);
     }
 }

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/ClasspathContext.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/ClasspathContext.java
@@ -4,13 +4,13 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import com.github.fridujo.junit.extension.classpath.maven.Maven;
+import com.github.fridujo.junit.extension.classpath.buildtool.maven.Maven;
 
-class ClasspathContext {
+public class ClasspathContext {
 
     private Maven maven;
 
-    Optional<Maven> getMaven(PathElement path) {
+    private Optional<Maven> getMaven(PathElement path) {
         if (maven == null) {
             maven = Maven.from(path).orElse(null);
         }

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/Gav.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/Gav.java
@@ -59,6 +59,11 @@ public class Gav {
         return jarPattern.matcher(rawJarPath).matches();
     }
 
+    public String toRelativePath() {
+        return groupId.replace('.', File.separatorChar) + File.separatorChar + artifactId + File.separatorChar + version + File.separatorChar
+            + artifactId + '-' + version + ".jar";
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/Artifact.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/Artifact.java
@@ -1,0 +1,30 @@
+package com.github.fridujo.junit.extension.classpath.buildtool;
+
+import java.util.Objects;
+
+import com.github.fridujo.junit.extension.classpath.Gav;
+import com.github.fridujo.junit.extension.classpath.PathElement;
+
+public class Artifact {
+    public final Gav gav;
+    public final PathElement path;
+
+    public Artifact(Gav gav, PathElement path) {
+        this.gav = gav;
+        this.path = path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Artifact artifact = (Artifact) o;
+        return gav.equals(artifact.gav) &&
+            path.equals(artifact.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(gav, path);
+    }
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/BuildTool.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/BuildTool.java
@@ -1,0 +1,10 @@
+package com.github.fridujo.junit.extension.classpath.buildtool;
+
+import java.util.Set;
+
+import com.github.fridujo.junit.extension.classpath.PathElement;
+
+public interface BuildTool {
+
+    Set<Artifact> listDependencies(PathElement path);
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/BuildToolResolver.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/BuildToolResolver.java
@@ -1,0 +1,11 @@
+package com.github.fridujo.junit.extension.classpath.buildtool;
+
+import java.util.Optional;
+import java.util.Set;
+
+import com.github.fridujo.junit.extension.classpath.PathElement;
+
+public interface BuildToolResolver {
+
+    Optional<BuildTool> resolve(Set<PathElement> classpath);
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/NoBuildToolFoundException.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/NoBuildToolFoundException.java
@@ -1,0 +1,4 @@
+package com.github.fridujo.junit.extension.classpath.buildtool;
+
+public class NoBuildToolFoundException extends RuntimeException {
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/Maven.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/Maven.java
@@ -1,4 +1,4 @@
-package com.github.fridujo.junit.extension.classpath.maven;
+package com.github.fridujo.junit.extension.classpath.buildtool.maven;
 
 import java.io.File;
 import java.util.Collections;

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenOperations.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenOperations.java
@@ -1,4 +1,4 @@
-package com.github.fridujo.junit.extension.classpath.maven;
+package com.github.fridujo.junit.extension.classpath.buildtool.maven;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenOperations.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenOperations.java
@@ -1,8 +1,6 @@
 package com.github.fridujo.junit.extension.classpath.buildtool.maven;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -18,12 +16,10 @@ import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingException;
 import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingResult;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectModelResolver;
 import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
 import org.apache.maven.repository.internal.DefaultVersionResolver;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.DefaultArtifactResolver;
 import org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager;
@@ -39,9 +35,9 @@ import com.github.fridujo.junit.extension.classpath.PathElement;
 
 abstract class MavenOperations {
 
-    private static final String ESC_SEP = Pattern.quote(File.separator);
+    static final String ESC_SEP = Pattern.quote(File.separator);
 
-    private static final Pattern MAVEN_ARTIFACT_PATH_PATTERN = Pattern.compile("(?:.*)" + ESC_SEP
+    static final Pattern MAVEN_ARTIFACT_PATH_PATTERN = Pattern.compile("(?:.*)" + ESC_SEP
         + "(?<artifactId>.*)" + ESC_SEP + "(?<version>.*)" + ESC_SEP
         + "\\k<artifactId>-\\k<version>" + Pattern.quote(".jar"));
 
@@ -69,41 +65,6 @@ abstract class MavenOperations {
         } catch (NoLocalRepositoryManagerException e) {
             throw new IllegalStateException(e);
         }
-    }
-
-    protected static String getVersion(Model model) {
-        String version = model.getVersion();
-        if (version != null) {
-            return version;
-        }
-        if (model.getParent() == null) {
-            throw new IllegalStateException("[" + model.getArtifactId() + "] No parent POM -> undefined version");
-        }
-        return model.getParent().getVersion();
-    }
-
-    protected static String getGroupId(Model model) {
-        String groupId = model.getGroupId();
-        if (groupId != null) {
-            return groupId;
-        }
-        if (model.getParent() == null) {
-            throw new IllegalStateException("[" + model.getArtifactId() + "] No parent POM -> undefined groupId");
-        }
-        return model.getParent().getGroupId();
-    }
-
-    protected static Optional<Model> getNonEffectiveModel(PathElement jarPath) {
-        Optional<Path> pomPath = getPomPath(jarPath);
-
-        return pomPath.map(pp -> {
-            MavenXpp3Reader reader = new MavenXpp3Reader();
-            try (InputStream is = Files.newInputStream(pp)) {
-                return reader.read(is);
-            } catch (IOException | XmlPullParserException e) {
-                return null;
-            }
-        });
     }
 
     private static Optional<Path> getPomPath(PathElement jarPath) {

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenResolver.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenResolver.java
@@ -1,0 +1,91 @@
+package com.github.fridujo.junit.extension.classpath.buildtool.maven;
+
+import static java.util.Optional.empty;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.github.fridujo.junit.extension.classpath.PathElement;
+import com.github.fridujo.junit.extension.classpath.buildtool.BuildTool;
+import com.github.fridujo.junit.extension.classpath.buildtool.BuildToolResolver;
+import com.github.fridujo.junit.extension.classpath.utils.Processes;
+import com.github.fridujo.junit.extension.classpath.utils.SystemVariables;
+
+public class MavenResolver implements BuildToolResolver {
+    static final String M2_HOME = "M2_HOME";
+    static final String USER_HOME = "user.home";
+
+    private static final Pattern MAVEN_HOME_LINE_PATTERN = Pattern.compile("^" + Pattern.quote("Maven home: ") + "(?<home>.+)$", Pattern.MULTILINE);
+    private static final Pattern LOCAL_REPOSITORY_PATTERN = Pattern.compile(Pattern.quote("<localRepository>") + "(?<localRepo>.+)" + Pattern.quote("</localRepository>"));
+
+    private final SystemVariables systemVariables = new SystemVariables();
+
+    @Override
+    public Optional<BuildTool> resolve(Set<PathElement> classpath) {
+        Optional<Path> mavenHome = getMavenHome();
+        Optional<Path> localRepository = getLocalRepository();
+
+        if (mavenHome.isPresent() && localRepository.isPresent()) {
+            return Optional.of(new Maven(mavenHome.get(), localRepository.get()));
+        } else {
+            return empty();
+        }
+    }
+
+    Optional<Path> getMavenHome() {
+        Optional<Path> mavenHomeFromSysProps = Optional.ofNullable(systemVariables.get(M2_HOME))
+            .map(Paths::get)
+            .filter(Files::exists)
+            .filter(Files::isDirectory);
+        if (mavenHomeFromSysProps.isPresent()) {
+            return mavenHomeFromSysProps;
+        } else {
+            return getMavenHomeFromCli();
+        }
+    }
+
+    Optional<Path> getLocalRepository() {
+        Optional<Path> defaultLocalRepositoryPath = Optional.ofNullable(systemVariables.get(USER_HOME))
+            .map(s -> Paths.get(s, ".m2", "repository"))
+            .filter(Files::exists)
+            .filter(Files::isDirectory);
+        if (defaultLocalRepositoryPath.isPresent()) {
+            return defaultLocalRepositoryPath;
+        } else {
+            return getLocalRepositoryFromCli();
+        }
+    }
+
+    private Optional<Path> getMavenHomeFromCli() {
+        Processes.ProcessResult result = Processes.launch("mvn -B -version");
+        if (result.exitCode != 0) {
+            return empty();
+        }
+        Matcher matcher = MAVEN_HOME_LINE_PATTERN.matcher(result.output);
+        if (matcher.find()) {
+            String homeStr = matcher.group("home");
+            return Optional.of(Paths.get(homeStr).normalize());
+        } else {
+            return empty();
+        }
+    }
+
+    private Optional<Path> getLocalRepositoryFromCli() {
+        Processes.ProcessResult result = Processes.launch("mvn -B help:effective-settings");
+        if (result.exitCode != 0) {
+            return empty();
+        }
+        Matcher matcher = LOCAL_REPOSITORY_PATTERN.matcher(result.output);
+        if (matcher.find()) {
+            String homeStr = matcher.group("localRepo");
+            return Optional.of(Paths.get(homeStr).normalize());
+        } else {
+            return empty();
+        }
+    }
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/junit/ModifiedClasspath.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/junit/ModifiedClasspath.java
@@ -1,4 +1,4 @@
-package com.github.fridujo.junit.extension.classpath;
+package com.github.fridujo.junit.extension.classpath.junit;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/junit/ModifiedClasspathExtension.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/junit/ModifiedClasspathExtension.java
@@ -1,4 +1,4 @@
-package com.github.fridujo.junit.extension.classpath;
+package com.github.fridujo.junit.extension.classpath.junit;
 
 import java.lang.reflect.Method;
 import java.util.Optional;
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.platform.commons.util.ReflectionUtils;
+
+import com.github.fridujo.junit.extension.classpath.Classpath;
+import com.github.fridujo.junit.extension.classpath.ClasspathContext;
 
 public class ModifiedClasspathExtension implements InvocationInterceptor {
 

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/utils/Processes.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/utils/Processes.java
@@ -1,0 +1,57 @@
+package com.github.fridujo.junit.extension.classpath.utils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.condition.OS;
+
+public class Processes {
+
+    public static ProcessResult launch(String command) {
+        ProcessBuilder builder = new ProcessBuilder();
+        if (OS.WINDOWS.isCurrentOs()) {
+            builder.command("cmd.exe", "/c", command);
+        } else {
+            builder.command("sh", "-c", command);
+        }
+
+        try {
+            Process process = builder.start();
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                return ProcessResult.error(exitCode);
+            }
+            String output = new Scanner(process.getInputStream(), StandardCharsets.UTF_8.name()).useDelimiter("\\A").next();
+            return ProcessResult.success(output);
+        } catch (IOException | InterruptedException e) {
+            return ProcessResult.error(e);
+        }
+    }
+
+    public static final class ProcessResult {
+
+        public final Exception cause;
+        public final int exitCode;
+        public final String output;
+
+        public ProcessResult(Exception cause, int exitCode, String output) {
+            this.cause = cause;
+            this.exitCode = exitCode;
+            this.output = output;
+        }
+
+        public static ProcessResult error(Exception cause) {
+            return new ProcessResult(cause, -1, null);
+        }
+
+        public static ProcessResult error(int exitCode) {
+            return new ProcessResult(null, exitCode, null);
+        }
+
+        public static ProcessResult success(String output) {
+            return new ProcessResult(null, 0, output);
+        }
+    }
+}

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/utils/Streams.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/utils/Streams.java
@@ -1,4 +1,4 @@
-package com.github.fridujo.junit.extension.classpath;
+package com.github.fridujo.junit.extension.classpath.utils;
 
 import java.util.Iterator;
 import java.util.function.BiFunction;

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/utils/Streams.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/utils/Streams.java
@@ -7,8 +7,11 @@ import java.util.stream.Stream;
 public class Streams {
 
     public static <T, U> U reduce(Stream<T> stream, U initialValue, BiFunction<U, T, U> accumulator) {
+        return reduce(stream.iterator(), initialValue, accumulator);
+    }
+
+    public static <T, U> U reduce(Iterator<T> iterator, U initialValue, BiFunction<U, T, U> accumulator) {
         U value = initialValue;
-        Iterator<T> iterator = stream.iterator();
         while (iterator.hasNext()) {
             value = accumulator.apply(value, iterator.next());
         }

--- a/src/main/java/com/github/fridujo/junit/extension/classpath/utils/SystemVariables.java
+++ b/src/main/java/com/github/fridujo/junit/extension/classpath/utils/SystemVariables.java
@@ -1,0 +1,10 @@
+package com.github.fridujo.junit.extension.classpath.utils;
+
+import java.util.Optional;
+
+public class SystemVariables {
+
+    public String get(String name) {
+        return Optional.ofNullable(System.getProperty(name)).orElse(System.getenv(name));
+    }
+}

--- a/src/main/resources/META-INF/services/com.github.fridujo.junit.extension.classpath.buildtool.BuildToolResolver
+++ b/src/main/resources/META-INF/services/com.github.fridujo.junit.extension.classpath.buildtool.BuildToolResolver
@@ -1,0 +1,1 @@
+com.github.fridujo.junit.extension.classpath.buildtool.maven.MavenResolver

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/ClasspathExclusionTests.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/ClasspathExclusionTests.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.jupiter.api.Test;
 
+import com.github.fridujo.junit.extension.classpath.junit.ModifiedClasspath;
+
 class ClasspathExclusionTests {
 
     @Test

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenResolverTest.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenResolverTest.java
@@ -1,0 +1,64 @@
+package com.github.fridujo.junit.extension.classpath.buildtool.maven;
+
+import static com.github.fridujo.junit.extension.classpath.buildtool.maven.MavenResolver.M2_HOME;
+import static com.github.fridujo.junit.extension.classpath.buildtool.maven.MavenResolver.USER_HOME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.github.fridujo.junit.extension.classpath.utils.Reflections;
+import com.github.fridujo.junit.extension.classpath.utils.SystemVariables;
+
+class MavenResolverTest {
+
+    @Test
+    void gather_maven_home_from_sys_props() {
+        assertThat(new SystemVariables().get(M2_HOME)).as(M2_HOME + " system property must be set on the build system (not required for users)").isNotBlank();
+
+        Optional<Path> mavenHome = new MavenResolver().getMavenHome();
+
+        assertThat(mavenHome).isPresent();
+        assertThat(mavenHome.get()).isDirectoryContaining(p -> Files.isDirectory(p) && p.getFileName().toString().equals("bin"));
+    }
+
+    @Test
+    void lookup_default_local_repository() {
+        assertThat(new SystemVariables().get(USER_HOME)).isNotBlank();
+
+        Optional<Path> localRepository = new MavenResolver().getLocalRepository();
+
+        assertThat(localRepository).isPresent();
+        assertThat(localRepository.get()).isDirectoryContaining(p -> Files.isDirectory(p) && p.getFileName().toString().equals("org"));
+    }
+
+    @Test
+    void gather_maven_home_from_cli() {
+        MavenResolver mavenResolver = new MavenResolver();
+        SystemVariables variables = Mockito.mock(SystemVariables.class);
+        Reflections.setFieldValue(mavenResolver, "systemVariables", variables);
+        when(variables.get(any())).thenReturn(null);
+        Optional<Path> mavenHome = mavenResolver.getMavenHome();
+
+        assertThat(mavenHome).isPresent();
+        assertThat(mavenHome.get()).isDirectoryContaining(p -> Files.isDirectory(p) && p.getFileName().toString().equals("bin"));
+    }
+
+    @Test
+    void lookup_local_repository_from_cli() {
+        MavenResolver mavenResolver = new MavenResolver();
+        SystemVariables variables = Mockito.mock(SystemVariables.class);
+        Reflections.setFieldValue(mavenResolver, "systemVariables", variables);
+        when(variables.get(any())).thenReturn("not_existing");
+        Optional<Path> localRepository = mavenResolver.getLocalRepository();
+
+        assertThat(localRepository).isPresent();
+        assertThat(localRepository.get()).isDirectoryContaining(p -> Files.isDirectory(p) && p.getFileName().toString().equals("org"));
+    }
+}

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenTest.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenTest.java
@@ -1,4 +1,4 @@
-package com.github.fridujo.junit.extension.classpath.maven;
+package com.github.fridujo.junit.extension.classpath.buildtool.maven;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenTest.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/buildtool/maven/MavenTest.java
@@ -2,22 +2,27 @@ package com.github.fridujo.junit.extension.classpath.buildtool.maven;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
 import com.github.fridujo.junit.extension.classpath.Classpath;
 import com.github.fridujo.junit.extension.classpath.Gav;
 import com.github.fridujo.junit.extension.classpath.PathElement;
+import com.github.fridujo.junit.extension.classpath.buildtool.BuildTool;
 
 class MavenTest {
 
     @Test
     void listDependencies_resolves() {
+        Optional<BuildTool> maven = new MavenResolver().resolve(Collections.emptySet());
         Gav gav = Gav.parse("junit-jupiter-api");
         PathElement pathElement = Classpath.current().pathElements.stream().filter(pe -> pe.matches(gav)).findFirst().get();
 
-        Set<Gav> deps = Maven.from(pathElement).get().listDependencies(pathElement);
+        Set<Gav> deps = maven.get().listDependencies(pathElement).stream().map(a -> a.gav).collect(Collectors.toSet());
 
         assertThat(deps).containsOnly(
             Gav.parse("org.junit.platform:junit-platform-commons:1.5.2"),

--- a/src/test/java/com/github/fridujo/junit/extension/classpath/utils/Reflections.java
+++ b/src/test/java/com/github/fridujo/junit/extension/classpath/utils/Reflections.java
@@ -1,0 +1,16 @@
+package com.github.fridujo.junit.extension.classpath.utils;
+
+import java.lang.reflect.Field;
+
+public class Reflections {
+
+    public static void setFieldValue(Object o, String fieldName, Object value) {
+        try {
+            Field field = o.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(o, value);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
This change split the logic between `Classpath` and `BuildTool` to avoid getting **Maven** leaking in core logic.

Next features will require more interactions with `BuildTool` (downloading replacements or additional libraries), an abstraction seems the good fit to limit complexity in the core `Classpath` code.